### PR TITLE
Add tox.ini for tox (http://tox.testrun.org/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 chromedriver.log
 coverage/
 dist/
+.tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27, pypy
+
+[testenv]
+commands = {envpython} online_docs/tests/runtests.py
+deps =
+    -r
+    {toxinidir}/requirements.txt


### PR DESCRIPTION
Sample tox output:

```
~/dev/git-repos/django-online-docs$ tox
GLOB sdist-make: /Users/marca/dev/git-repos/django-online-docs/setup.py
py26 sdist-reinst: /Users/marca/dev/git-repos/django-online-docs/.tox/dist/django-online-docs-0.3.zip
py26 runtests: commands[0]
nosetests --verbosity 2
Creating test database for alias 'default' (':memory:')...
Creating tables ...
Creating table django_admin_log
Creating table auth_permission
Creating table auth_group_permissions
Creating table auth_group
Creating table auth_user_user_permissions
Creating table auth_user_groups
Creating table auth_user
Creating table django_content_type
Creating table django_session
Creating table django_site
Installing custom SQL ...
Installing indexes ...
Installed 0 object(s) from 0 fixture(s)
test_get_document_content (online_docs.tests.integration_tests.views_tests.OnlineDocsViewTestCase) ... ok
test_get_document_file_path (online_docs.tests.integration_tests.views_tests.OnlineDocsViewTestCase) ... ok
test_get_document_name (online_docs.tests.integration_tests.views_tests.OnlineDocsViewTestCase) ... ok
test_view (online_docs.tests.integration_tests.views_tests.OnlineDocsViewTestCase) ... ok
test_tag (online_docs.tests.online_docs_tags_tests.RenderDocsTestCase) ... ok

----------------------------------------------------------------------
Ran 5 tests in 0.060s

OK
Destroying test database for alias 'default' (':memory:')...

HTML reports were output to '/Users/marca/dev/git-repos/django-online-docs/online_docs/tests/coverage'
py27 sdist-reinst: /Users/marca/dev/git-repos/django-online-docs/.tox/dist/django-online-docs-0.3.zip
py27 runtests: commands[0]
nosetests --verbosity 2
Creating test database for alias 'default' (':memory:')...
Creating tables ...
Creating table django_admin_log
Creating table auth_permission
Creating table auth_group_permissions
Creating table auth_group
Creating table auth_user_user_permissions
Creating table auth_user_groups
Creating table auth_user
Creating table django_content_type
Creating table django_session
Creating table django_site
Installing custom SQL ...
Installing indexes ...
Installed 0 object(s) from 0 fixture(s)
test_get_document_content (online_docs.tests.integration_tests.views_tests.OnlineDocsViewTestCase) ... ok
test_get_document_file_path (online_docs.tests.integration_tests.views_tests.OnlineDocsViewTestCase) ... ok
test_get_document_name (online_docs.tests.integration_tests.views_tests.OnlineDocsViewTestCase) ... ok
test_view (online_docs.tests.integration_tests.views_tests.OnlineDocsViewTestCase) ... ok
test_tag (online_docs.tests.online_docs_tags_tests.RenderDocsTestCase) ... ok

----------------------------------------------------------------------
Ran 5 tests in 0.062s

OK
Destroying test database for alias 'default' (':memory:')...

HTML reports were output to '/Users/marca/dev/git-repos/django-online-docs/online_docs/tests/coverage'
_________________________________________________________________________ summary __________________________________________________________________________
  py26: commands succeeded
  py27: commands succeeded
  congratulations :)
```
